### PR TITLE
Throw when transferring insufficient fee in SMS verifier.

### DIFF
--- a/SMSVerification.sol
+++ b/SMSVerification.sol
@@ -54,7 +54,7 @@ contract SimpleCertifier is Owned, Certifier {
 
 contract ProofOfSMS is SimpleCertifier {
 
-	modifier when_fee_paid { if (msg.value < fee) return; _; }
+	modifier when_fee_paid { if (msg.value < fee) throw; _; }
 
 	event Requested(address indexed who);
 	event Puzzled(address indexed who, bytes32 puzzle);

--- a/SMSVerification.sol
+++ b/SMSVerification.sol
@@ -61,7 +61,7 @@ contract ProofOfSMS is SimpleCertifier {
 
 	function request() payable when_fee_paid {
 		if (certs[msg.sender].active)
-			return;
+			throw;
 		Requested(msg.sender);
 	}
 


### PR DESCRIPTION
Closes: https://github.com/paritytech/sms-verification/issues/9

Without a `throw` the payment will be accepted, alternatively we can just send the funds back.