### PR TITLE
fix missing return in transfer(address,uint256)

### DIFF
--- a/GavCoin.sol
+++ b/GavCoin.sol
@@ -63,6 +63,7 @@ contract GavCoin {
 		Transfer(msg.sender, _to, _value);
 		accounts[msg.sender].balance -= _value;
 		accounts[_to].balance += _value;
+        return true;
 	}
 	function transferFrom(address _from, address _to, uint256 _value) when_owns(_from, _value) when_has_allowance(_from, msg.sender, _value) returns (bool success) {
 		Transfer(_from, _to, _value);


### PR DESCRIPTION
I'm testing a contract using GavCoin and noticed a programming error in GavCoin.
My contract have the following:
```
    /**
     * @dev withdraw token amount to dest
     **/
    function withdraw(address _tokenAddr, address _dest, uint _amount)
     internal {
        if(!ERC20(_tokenAddr).transfer(_dest,_amount)) throw;
        tokenBalances[_tokenAddr] -= _amount;
        TokenWithdrawn(_tokenAddr, _dest, _amount);
    }
```
In GavCoin, `ERC20(_tokenAddr).transfer(_dest,_amount)` always return false.
I've verified GavCoin source, here https://kovan.etherscan.io/address/0x4733659a5cb7896a65c918add6f59c5148fb5ffa#code.