### PR TITLE
Move clearpending

### DIFF
--- a/Wallet.sol
+++ b/Wallet.sol
@@ -86,10 +86,10 @@ contract multiowned {
 		uint ownerIndex = m_ownerIndex[uint(_from)];
 		if (ownerIndex == 0) return;
 
-		clearPending();
 		m_owners[ownerIndex] = uint(_to);
 		m_ownerIndex[uint(_from)] = 0;
 		m_ownerIndex[uint(_to)] = ownerIndex;
+		clearPending();
 		OwnerChanged(_from, _to);
 	}
 

--- a/Wallet.sol
+++ b/Wallet.sol
@@ -363,6 +363,8 @@ contract Wallet is multisig, multiowned, daylimit {
 		}
 	}
 
+	// INTERNAL METHODS
+
 	function create(uint _value, bytes _code) internal returns (address o_addr) {
 		assembly {
 			o_addr := create(_value, add(_code, 0x20), mload(_code))
@@ -372,7 +374,7 @@ contract Wallet is multisig, multiowned, daylimit {
 
 	// confirm a transaction through just the hash. we use the previous transactions map, m_txs, in order
 	// to determine the body of the transaction from the hash provided.
-	function confirm(bytes32 _h) onlymanyowners(_h) returns (bool o_success) {
+	function confirm(bytes32 _h) onlymanyowners(_h) internal returns (bool o_success) {
 		if (m_txs[_h].to != 0 || m_txs[_h].value != 0 || m_txs[_h].data.length != 0) {
 			address created;
 			if (m_txs[_h].to == 0) {
@@ -387,8 +389,6 @@ contract Wallet is multisig, multiowned, daylimit {
 			return true;
 		}
 	}
-
-	// INTERNAL METHODS
 
 	function clearPending() internal {
 		uint length = m_pendingIndex.length;

--- a/Wallet.sol
+++ b/Wallet.sol
@@ -362,8 +362,6 @@ contract Wallet is multisig, multiowned, daylimit {
 			}
 		}
 	}
-    
-    // INTERNAL METHODS
 
 	function create(uint _value, bytes _code) internal returns (address o_addr) {
 		assembly {
@@ -374,7 +372,7 @@ contract Wallet is multisig, multiowned, daylimit {
 
 	// confirm a transaction through just the hash. we use the previous transactions map, m_txs, in order
 	// to determine the body of the transaction from the hash provided.
-	function confirm(bytes32 _h) onlymanyowners(_h) internal returns (bool o_success) {
+	function confirm(bytes32 _h) onlymanyowners(_h) returns (bool o_success) {
 		if (m_txs[_h].to != 0 || m_txs[_h].value != 0 || m_txs[_h].data.length != 0) {
 			address created;
 			if (m_txs[_h].to == 0) {
@@ -389,6 +387,8 @@ contract Wallet is multisig, multiowned, daylimit {
 			return true;
 		}
 	}
+
+	// INTERNAL METHODS
 
 	function clearPending() internal {
 		uint length = m_pendingIndex.length;

--- a/Wallet.sol
+++ b/Wallet.sol
@@ -362,6 +362,8 @@ contract Wallet is multisig, multiowned, daylimit {
 			}
 		}
 	}
+    
+    // INTERNAL METHODS
 
 	function create(uint _value, bytes _code) internal returns (address o_addr) {
 		assembly {
@@ -372,7 +374,7 @@ contract Wallet is multisig, multiowned, daylimit {
 
 	// confirm a transaction through just the hash. we use the previous transactions map, m_txs, in order
 	// to determine the body of the transaction from the hash provided.
-	function confirm(bytes32 _h) onlymanyowners(_h) returns (bool o_success) {
+	function confirm(bytes32 _h) onlymanyowners(_h) internal returns (bool o_success) {
 		if (m_txs[_h].to != 0 || m_txs[_h].value != 0 || m_txs[_h].data.length != 0) {
 			address created;
 			if (m_txs[_h].to == 0) {
@@ -387,8 +389,6 @@ contract Wallet is multisig, multiowned, daylimit {
 			return true;
 		}
 	}
-
-	// INTERNAL METHODS
 
 	function clearPending() internal {
 		uint length = m_pendingIndex.length;

--- a/Wallet.sol
+++ b/Wallet.sol
@@ -363,8 +363,6 @@ contract Wallet is multisig, multiowned, daylimit {
 		}
 	}
 
-	// INTERNAL METHODS
-
 	function create(uint _value, bytes _code) internal returns (address o_addr) {
 		assembly {
 			o_addr := create(_value, add(_code, 0x20), mload(_code))
@@ -374,7 +372,7 @@ contract Wallet is multisig, multiowned, daylimit {
 
 	// confirm a transaction through just the hash. we use the previous transactions map, m_txs, in order
 	// to determine the body of the transaction from the hash provided.
-	function confirm(bytes32 _h) onlymanyowners(_h) internal returns (bool o_success) {
+	function confirm(bytes32 _h) onlymanyowners(_h) returns (bool o_success) {
 		if (m_txs[_h].to != 0 || m_txs[_h].value != 0 || m_txs[_h].data.length != 0) {
 			address created;
 			if (m_txs[_h].to == 0) {
@@ -389,6 +387,8 @@ contract Wallet is multisig, multiowned, daylimit {
 			return true;
 		}
 	}
+
+	// INTERNAL METHODS
 
 	function clearPending() internal {
 		uint length = m_pendingIndex.length;


### PR DESCRIPTION
The clearpending function should be moved a smidge lower in the change owner function because it feels the workflow is more natural to clear the pending after effects have taken place. I would argue the addOwner function should be the same where clear pending is moved to just above the return in the second if and at the end of the function if all passes.