### PR TITLE
Add versioning

### DIFF
--- a/Wallet.sol
+++ b/Wallet.sol
@@ -8,6 +8,7 @@
 // use modifiers onlyowner (just own owned) or onlymanyowners(hash), whereby the same hash must be provided by
 // some number (specified in constructor) of the set of owners (specified in the constructor, modifiable) before the
 // interior is executed.
+// +Version: Parity fork 1.0
 
 pragma solidity ^0.4.7;
 


### PR DESCRIPTION
It would be nice to have some sort of versioning in the copyright header. In particular, when I had (hastily) deployed the parity wallet, I had glanced at the comment block and assumed it was the original Gav Wood/Ethereum foundation wallet with some very minor changes. I doubt anyone will make that mistake again; I certainly won't, but it seems like a sensible thing to do.