### PR TITLE
multiowned constructor: throw if duplicated or zero addr owners

### DIFF
--- a/Wallet.sol
+++ b/Wallet.sol
@@ -59,6 +59,10 @@ contract multiowned {
 		require(_owners.length >= _required);
 		m_numOwners = _owners.length;
 		for (uint i = 0; i < _owners.length; ++i) {
+			if (m_ownerIndex[uint(_owners[i])] != 0 || _owners[i] == 0) {
+				throw;
+			}
+
 			m_owners[1 + i] = uint(_owners[i]);
 			m_ownerIndex[uint(_owners[i])] = 1 + i;
 		}


### PR DESCRIPTION
This commit adds a check in the `multiowned` constructor in Wallet.sol to prevent accidental deployment of a wallet with duplicated owners or invalid (zero byte) addresses.

This is similar to the check in the Gnosis/Consensys multisig: https://github.com/ConsenSys/MultiSigWallet/blob/master/contracts/solidity/MultiSigWallet.sol#L110
