### PR TITLE
Add the Wallet Library

### DIFF
--- a/Wallet.sol
+++ b/Wallet.sol
@@ -132,11 +132,11 @@ contract multiowned {
 		return address(m_owners[ownerIndex + 1]);
 	}
 
-	function isOwner(address _addr) returns (bool) {
+	function isOwner(address _addr) public returns (bool) {
 		return m_ownerIndex[uint(_addr)] > 0;
 	}
 
-	function hasConfirmed(bytes32 _operation, address _owner) constant returns (bool) {
+	function hasConfirmed(bytes32 _operation, address _owner) external constant returns (bool) {
 		var pending = m_pending[_operation];
 		uint ownerIndex = m_ownerIndex[uint(_owner)];
 
@@ -252,7 +252,7 @@ contract daylimit is multiowned {
 
 	// checks to see if there is at least `_value` left from the daily limit today. if there is, subtracts it and
 	// returns true. otherwise just returns false.
-	function underLimit(uint _value) internal onlyowner returns (bool) {
+	function underLimit(uint _value) onlyowner internal returns (bool) {
 		// reset the spend limit if we're on a different day to last time.
 		if (today() > m_lastDay) {
 			m_spentToday = 0;
@@ -296,7 +296,7 @@ contract multisig {
 	// TODO: document
 	function changeOwner(address _from, address _to) external;
 	function execute(address _to, uint _value, bytes _data) external returns (bytes32 o_hash);
-	function confirm(bytes32 _h) returns (bool o_success);
+	function confirm(bytes32 _h) public returns (bool o_success);
 }
 
 contract creator {
@@ -348,7 +348,7 @@ contract Wallet is multisig, multiowned, daylimit, creator {
 	// If not, goes into multisig process. We provide a hash on return to allow the sender to provide
 	// shortcuts for the other confirmations (allowing them to avoid replicating the _to, _value
 	// and _data arguments). They still get the option of using them if they want, anyways.
-	function execute(address _to, uint _value, bytes _data) external onlyowner returns (bytes32 o_hash) {
+	function execute(address _to, uint _value, bytes _data) onlyowner external returns (bytes32 o_hash) {
 		// first, take the opportunity to check that we're under the daily limit.
 		if ((_data.length == 0 && underLimit(_value)) || m_required == 1) {
 			// yes - just execute the call.
@@ -380,7 +380,7 @@ contract Wallet is multisig, multiowned, daylimit, creator {
 
 	// confirm a transaction through just the hash. we use the previous transactions map, m_txs, in order
 	// to determine the body of the transaction from the hash provided.
-	function confirm(bytes32 _h) onlymanyowners(_h) returns (bool o_success) {
+	function confirm(bytes32 _h) onlymanyowners(_h) public returns (bool o_success) {
 		if (m_txs[_h].to != 0 || m_txs[_h].value != 0 || m_txs[_h].data.length != 0) {
 			address created;
 			if (m_txs[_h].to == 0) {

--- a/wallet/WalletLibrary.sol
+++ b/wallet/WalletLibrary.sol
@@ -1,0 +1,417 @@
+//sol Wallet
+// Multi-sig, daily-limited account proxy/wallet.
+// @authors:
+// Gav Wood <g@ethdev.com>
+// Nicolas Gotchac <nicolas@parity.io>
+// inheritable "property" contract that enables methods to be protected by requiring the acquiescence of either a
+// single, or, crucially, each of a number of, designated owners.
+// usage:
+// use modifiers onlyowner (just own owned) or onlymanyowners(hash), whereby the same hash must be provided by
+// some number (specified in constructor) of the set of owners (specified in the constructor, modifiable) before the
+// interior is executed.
+
+pragma solidity ^0.4.7;
+
+contract multiowned {
+
+	// TYPES
+
+	// struct for the status of a pending operation.
+	struct PendingState {
+		uint yetNeeded;
+		uint ownersDone;
+		uint index;
+	}
+
+	// EVENTS
+
+	// this contract only has six types of events: it can accept a confirmation, in which case
+	// we record owner and operation (hash) alongside it.
+	event Confirmation(address owner, bytes32 operation);
+	event Revoke(address owner, bytes32 operation);
+	// some others are in the case of an owner changing.
+	event OwnerChanged(address oldOwner, address newOwner);
+	event OwnerAdded(address newOwner);
+	event OwnerRemoved(address oldOwner);
+	// the last one is emitted if the required signatures change
+	event RequirementChanged(uint newRequirement);
+
+	// MODIFIERS
+
+	// simple single-sig function modifier.
+	modifier onlyowner {
+		if (isOwner(msg.sender))
+			_;
+	}
+	// multi-sig function modifier: the operation must have an intrinsic hash in order
+	// that later attempts can be realised as the same underlying operation and
+	// thus count as confirmations.
+	modifier onlymanyowners(bytes32 _operation) {
+		if (confirmAndCheck(_operation))
+			_;
+	}
+
+	modifier only_uninitialized {
+		require(m_numOwners == 0);
+		_;
+	}
+
+	// METHODS
+
+	// constructor is given number of sigs required to do protected "onlymanyowners" transactions
+	// as well as the selection of addresses capable of confirming them.
+	function init_multiowned(address[] _owners, uint _required) only_uninitialized internal {
+		require(_required > 0);
+		require(_owners.length >= _required);
+		m_numOwners = _owners.length;
+		for (uint i = 0; i < _owners.length; ++i) {
+			m_owners[1 + i] = uint(_owners[i]);
+			m_ownerIndex[uint(_owners[i])] = 1 + i;
+		}
+		m_required = _required;
+	}
+
+	// Revokes a prior confirmation of the given operation
+	function revoke(bytes32 _operation) external {
+		uint ownerIndex = m_ownerIndex[uint(msg.sender)];
+		// make sure they're an owner
+		if (ownerIndex == 0) return;
+		uint ownerIndexBit = 2**ownerIndex;
+		var pending = m_pending[_operation];
+		if (pending.ownersDone & ownerIndexBit > 0) {
+			pending.yetNeeded++;
+			pending.ownersDone -= ownerIndexBit;
+			Revoke(msg.sender, _operation);
+		}
+	}
+
+	// Replaces an owner `_from` with another `_to`.
+	function changeOwner(address _from, address _to) onlymanyowners(sha3(msg.data)) external {
+		if (isOwner(_to)) return;
+		uint ownerIndex = m_ownerIndex[uint(_from)];
+		if (ownerIndex == 0) return;
+
+		clearPending();
+		m_owners[ownerIndex] = uint(_to);
+		m_ownerIndex[uint(_from)] = 0;
+		m_ownerIndex[uint(_to)] = ownerIndex;
+		OwnerChanged(_from, _to);
+	}
+
+	function addOwner(address _owner) onlymanyowners(sha3(msg.data)) external {
+		if (isOwner(_owner)) return;
+
+		clearPending();
+		if (m_numOwners >= c_maxOwners)
+			reorganizeOwners();
+		if (m_numOwners >= c_maxOwners)
+			return;
+		m_numOwners++;
+		m_owners[m_numOwners] = uint(_owner);
+		m_ownerIndex[uint(_owner)] = m_numOwners;
+		OwnerAdded(_owner);
+	}
+
+	function removeOwner(address _owner) onlymanyowners(sha3(msg.data)) external {
+		uint ownerIndex = m_ownerIndex[uint(_owner)];
+		if (ownerIndex == 0) return;
+		if (m_required > m_numOwners - 1) return;
+
+		m_owners[ownerIndex] = 0;
+		m_ownerIndex[uint(_owner)] = 0;
+		clearPending();
+		reorganizeOwners(); //make sure m_numOwner is equal to the number of owners and always points to the optimal free slot
+		OwnerRemoved(_owner);
+	}
+
+	function changeRequirement(uint _newRequired) onlymanyowners(sha3(msg.data)) external {
+		if (_newRequired == 0) return;
+		if (_newRequired > m_numOwners) return;
+		m_required = _newRequired;
+		clearPending();
+		RequirementChanged(_newRequired);
+	}
+
+	// Gets an owner by 0-indexed position (using numOwners as the count)
+	function getOwner(uint ownerIndex) external constant returns (address) {
+		return address(m_owners[ownerIndex + 1]);
+	}
+
+	function isOwner(address _addr) returns (bool) {
+		return m_ownerIndex[uint(_addr)] > 0;
+	}
+
+	function hasConfirmed(bytes32 _operation, address _owner) constant returns (bool) {
+		var pending = m_pending[_operation];
+		uint ownerIndex = m_ownerIndex[uint(_owner)];
+
+		// make sure they're an owner
+		if (ownerIndex == 0) return false;
+
+		// determine the bit to set for this owner.
+		uint ownerIndexBit = 2**ownerIndex;
+		return !(pending.ownersDone & ownerIndexBit == 0);
+	}
+
+	// INTERNAL METHODS
+
+	function confirmAndCheck(bytes32 _operation) internal returns (bool) {
+		// determine what index the present sender is:
+		uint ownerIndex = m_ownerIndex[uint(msg.sender)];
+		// make sure they're an owner
+		if (ownerIndex == 0) return;
+
+		var pending = m_pending[_operation];
+		// if we're not yet working on this operation, switch over and reset the confirmation status.
+		if (pending.yetNeeded == 0) {
+			// reset count of confirmations needed.
+			pending.yetNeeded = m_required;
+			// reset which owners have confirmed (none) - set our bitmap to 0.
+			pending.ownersDone = 0;
+			pending.index = m_pendingIndex.length++;
+			m_pendingIndex[pending.index] = _operation;
+		}
+		// determine the bit to set for this owner.
+		uint ownerIndexBit = 2**ownerIndex;
+		// make sure we (the message sender) haven't confirmed this operation previously.
+		if (pending.ownersDone & ownerIndexBit == 0) {
+			Confirmation(msg.sender, _operation);
+			// ok - check if count is enough to go ahead.
+			if (pending.yetNeeded <= 1) {
+				// enough confirmations: reset and run interior.
+				delete m_pendingIndex[m_pending[_operation].index];
+				delete m_pending[_operation];
+				return true;
+			}
+			else
+			{
+				// not enough: record that this owner in particular confirmed.
+				pending.yetNeeded--;
+				pending.ownersDone |= ownerIndexBit;
+			}
+		}
+	}
+
+	function reorganizeOwners() private {
+		uint free = 1;
+		while (free < m_numOwners)
+		{
+			while (free < m_numOwners && m_owners[free] != 0) free++;
+			while (m_numOwners > 1 && m_owners[m_numOwners] == 0) m_numOwners--;
+			if (free < m_numOwners && m_owners[m_numOwners] != 0 && m_owners[free] == 0)
+			{
+				m_owners[free] = m_owners[m_numOwners];
+				m_ownerIndex[m_owners[free]] = free;
+				m_owners[m_numOwners] = 0;
+			}
+		}
+	}
+
+	function clearPending() internal {
+		uint length = m_pendingIndex.length;
+		for (uint i = 0; i < length; ++i)
+			if (m_pendingIndex[i] != 0)
+				delete m_pending[m_pendingIndex[i]];
+		delete m_pendingIndex;
+	}
+
+	// FIELDS
+
+	// the number of owners that must confirm the same operation before it is run.
+	uint public m_required;
+	// pointer used to find a free slot in m_owners
+	uint public m_numOwners;
+
+	// list of owners
+	uint[256] m_owners;
+	uint constant c_maxOwners = 250;
+	// index on the list of owners to allow reverse lookup
+	mapping(uint => uint) m_ownerIndex;
+	// the ongoing operations.
+	mapping(bytes32 => PendingState) m_pending;
+	bytes32[] m_pendingIndex;
+}
+
+// inheritable "property" contract that enables methods to be protected by placing a linear limit (specifiable)
+// on a particular resource per calendar day. is multiowned to allow the limit to be altered. resource that method
+// uses is specified in the modifier.
+contract daylimit is multiowned {
+
+	// METHODS
+
+	// constructor - stores initial daily limit and records the present day's index.
+	function init_daylimit(uint _limit) only_uninitialized internal {
+		m_dailyLimit = _limit;
+		m_lastDay = today();
+	}
+	// (re)sets the daily limit. needs many of the owners to confirm. doesn't alter the amount already spent today.
+	function setDailyLimit(uint _newLimit) onlymanyowners(sha3(msg.data)) external {
+		m_dailyLimit = _newLimit;
+	}
+	// resets the amount already spent today. needs many of the owners to confirm.
+	function resetSpentToday() onlymanyowners(sha3(msg.data)) external {
+		m_spentToday = 0;
+	}
+
+	// INTERNAL METHODS
+
+	// checks to see if there is at least `_value` left from the daily limit today. if there is, subtracts it and
+	// returns true. otherwise just returns false.
+	function underLimit(uint _value) internal onlyowner returns (bool) {
+		// reset the spend limit if we're on a different day to last time.
+		if (today() > m_lastDay) {
+			m_spentToday = 0;
+			m_lastDay = today();
+		}
+		// check to see if there's enough left - if so, subtract and return true.
+		// overflow protection                    // dailyLimit check
+		if (m_spentToday + _value >= m_spentToday && m_spentToday + _value <= m_dailyLimit) {
+			m_spentToday += _value;
+			return true;
+		}
+		return false;
+	}
+	// determines today's index.
+	function today() private constant returns (uint) { return now / 1 days; }
+
+	// FIELDS
+
+	uint public m_dailyLimit;
+	uint public m_spentToday;
+	uint public m_lastDay;
+}
+
+// interface contract for multisig proxy contracts; see below for docs.
+contract multisig {
+
+	// EVENTS
+
+	// logged events:
+	// Funds has arrived into the wallet (record how much).
+	event Deposit(address _from, uint value);
+	// Single transaction going out of the wallet (record who signed for it, how much, and to whom it's going).
+	event SingleTransact(address owner, uint value, address to, bytes data, address created);
+	// Multi-sig transaction going out of the wallet (record who signed for it last, the operation hash, how much, and to whom it's going).
+	event MultiTransact(address owner, bytes32 operation, uint value, address to, bytes data, address created);
+	// Confirmation still needed for a transaction.
+	event ConfirmationNeeded(bytes32 operation, address initiator, uint value, address to, bytes data);
+
+	// FUNCTIONS
+
+	// TODO: document
+	function changeOwner(address _from, address _to) external;
+	function execute(address _to, uint _value, bytes _data) external returns (bytes32 o_hash);
+	function confirm(bytes32 _h) returns (bool o_success);
+}
+
+contract creator {
+	function doCreate(uint _value, bytes _code) internal returns (address o_addr) {
+		bool failed;
+		assembly {
+			o_addr := create(_value, add(_code, 0x20), mload(_code))
+			failed := iszero(extcodesize(o_addr))
+		}
+		require(!failed);
+	}
+}
+
+// usage:
+// bytes32 h = Wallet(w).from(oneOwner).execute(to, value, data);
+// Wallet(w).from(anotherOwner).confirm(h);
+contract WalletLibrary is multisig, multiowned, daylimit, creator {
+
+	// TYPES
+
+	// Transaction structure to remember details of transaction lest it need be saved for a later call.
+	struct Transaction {
+		address to;
+		uint value;
+		bytes data;
+	}
+
+	// METHODS
+
+	// constructor - just pass on the owner array to the multiowned and
+	// the limit to daylimit
+	function init_wallet(address[] _owners, uint _required, uint _daylimit) only_uninitialized external {
+		init_daylimit(_daylimit);
+		init_multiowned(_owners, _required);
+	}
+
+	// kills the contract sending everything to `_to`.
+	function kill(address _to) onlymanyowners(sha3(msg.data)) external {
+		suicide(_to);
+	}
+
+	// gets called when no other function matches
+	function() payable {
+		// just being sent some cash?
+		if (msg.value > 0)
+			Deposit(msg.sender, msg.value);
+	}
+
+	// Outside-visible transact entry point. Executes transaction immediately if below daily spend limit.
+	// If not, goes into multisig process. We provide a hash on return to allow the sender to provide
+	// shortcuts for the other confirmations (allowing them to avoid replicating the _to, _value
+	// and _data arguments). They still get the option of using them if they want, anyways.
+	function execute(address _to, uint _value, bytes _data) external onlyowner returns (bytes32 o_hash) {
+		// first, take the opportunity to check that we're under the daily limit.
+		if ((_data.length == 0 && underLimit(_value)) || m_required == 1) {
+			// yes - just execute the call.
+			address created;
+			if (_to == 0) {
+				created = create(_value, _data);
+			} else {
+				require(_to.call.value(_value)(_data));
+			}
+			SingleTransact(msg.sender, _value, _to, _data, created);
+		} else {
+			// determine our operation hash.
+			o_hash = sha3(msg.data, block.number);
+			// store if it's new
+			if (m_txs[o_hash].to == 0 && m_txs[o_hash].value == 0 && m_txs[o_hash].data.length == 0) {
+				m_txs[o_hash].to = _to;
+				m_txs[o_hash].value = _value;
+				m_txs[o_hash].data = _data;
+			}
+			if (!confirm(o_hash)) {
+				ConfirmationNeeded(o_hash, msg.sender, _value, _to, _data);
+			}
+		}
+	}
+
+	function create(uint _value, bytes _code) internal returns (address o_addr) {
+		return doCreate(_value, _code);
+	}
+
+	// confirm a transaction through just the hash. we use the previous transactions map, m_txs, in order
+	// to determine the body of the transaction from the hash provided.
+	function confirm(bytes32 _h) onlymanyowners(_h) returns (bool o_success) {
+		if (m_txs[_h].to != 0 || m_txs[_h].value != 0 || m_txs[_h].data.length != 0) {
+			address created;
+			if (m_txs[_h].to == 0) {
+				created = create(m_txs[_h].value, m_txs[_h].data);
+			} else {
+				require(m_txs[_h].to.call.value(m_txs[_h].value)(m_txs[_h].data));
+			}
+
+			MultiTransact(msg.sender, _h, m_txs[_h].value, m_txs[_h].to, m_txs[_h].data, created);
+			delete m_txs[_h];
+			return true;
+		}
+	}
+
+	// INTERNAL METHODS
+
+	function clearPending() internal {
+		uint length = m_pendingIndex.length;
+		for (uint i = 0; i < length; ++i)
+			delete m_txs[m_pendingIndex[i]];
+		super.clearPending();
+	}
+
+	// FIELDS
+
+	// pending transactions we have at present.
+	mapping (bytes32 => Transaction) m_txs;
+}

--- a/wallet/WalletLibrary.sol
+++ b/wallet/WalletLibrary.sol
@@ -334,7 +334,14 @@ contract WalletLibrary is multisig, multiowned, daylimit, creator {
 
 	// constructor - just pass on the owner array to the multiowned and
 	// the limit to daylimit
-	function init_wallet(address[] _owners, uint _required, uint _daylimit) only_uninitialized external {
+	function WalletLibrary() {
+		address[] owners;
+
+		owners.push(address(0x0));
+		init_wallet(owners, 1, 0);
+	}
+
+	function init_wallet(address[] _owners, uint _required, uint _daylimit) only_uninitialized public {
 		init_daylimit(_daylimit);
 		init_multiowned(_owners, _required);
 	}

--- a/wallet/WalletLibrary.sol
+++ b/wallet/WalletLibrary.sol
@@ -9,8 +9,9 @@
 // use modifiers onlyowner (just own owned) or onlymanyowners(hash), whereby the same hash must be provided by
 // some number (specified in constructor) of the set of owners (specified in the constructor, modifiable) before the
 // interior is executed.
+// +Version: Parity fork 1.0
 
-pragma solidity ^0.4.7;
+pragma solidity ^0.4.13;
 
 contract multiowned {
 
@@ -177,7 +178,7 @@ contract multiowned {
 		if (pending.ownersDone & ownerIndexBit == 0) {
 			Confirmation(msg.sender, _operation);
 			// ok - check if count is enough to go ahead.
-			if (pending.yetNeeded <= 1) {
+			if (pending.yetNeeded == 1) {
 				// enough confirmations: reset and run interior.
 				delete m_pendingIndex[m_pending[_operation].index];
 				delete m_pending[_operation];

--- a/wallet/WalletLibrary.sol
+++ b/wallet/WalletLibrary.sol
@@ -138,11 +138,11 @@ contract multiowned {
 		return address(m_owners[ownerIndex + 1]);
 	}
 
-	function isOwner(address _addr) returns (bool) {
+	function isOwner(address _addr) public constant returns (bool) {
 		return m_ownerIndex[uint(_addr)] > 0;
 	}
 
-	function hasConfirmed(bytes32 _operation, address _owner) constant returns (bool) {
+	function hasConfirmed(bytes32 _operation, address _owner) external constant returns (bool) {
 		var pending = m_pending[_operation];
 		uint ownerIndex = m_ownerIndex[uint(_owner)];
 
@@ -258,7 +258,7 @@ contract daylimit is multiowned {
 
 	// checks to see if there is at least `_value` left from the daily limit today. if there is, subtracts it and
 	// returns true. otherwise just returns false.
-	function underLimit(uint _value) internal onlyowner returns (bool) {
+	function underLimit(uint _value) onlyowner internal returns (bool) {
 		// reset the spend limit if we're on a different day to last time.
 		if (today() > m_lastDay) {
 			m_spentToday = 0;
@@ -302,7 +302,7 @@ contract multisig {
 	// TODO: document
 	function changeOwner(address _from, address _to) external;
 	function execute(address _to, uint _value, bytes _data) external returns (bytes32 o_hash);
-	function confirm(bytes32 _h) returns (bool o_success);
+	function confirm(bytes32 _h) public returns (bool o_success);
 }
 
 contract creator {
@@ -362,7 +362,7 @@ contract WalletLibrary is multisig, multiowned, daylimit, creator {
 	// If not, goes into multisig process. We provide a hash on return to allow the sender to provide
 	// shortcuts for the other confirmations (allowing them to avoid replicating the _to, _value
 	// and _data arguments). They still get the option of using them if they want, anyways.
-	function execute(address _to, uint _value, bytes _data) external onlyowner returns (bytes32 o_hash) {
+	function execute(address _to, uint _value, bytes _data) onlyowner external returns (bytes32 o_hash) {
 		// first, take the opportunity to check that we're under the daily limit.
 		if ((_data.length == 0 && underLimit(_value)) || m_required == 1) {
 			// yes - just execute the call.
@@ -394,7 +394,7 @@ contract WalletLibrary is multisig, multiowned, daylimit, creator {
 
 	// confirm a transaction through just the hash. we use the previous transactions map, m_txs, in order
 	// to determine the body of the transaction from the hash provided.
-	function confirm(bytes32 _h) onlymanyowners(_h) returns (bool o_success) {
+	function confirm(bytes32 _h) onlymanyowners(_h) public returns (bool o_success) {
 		if (m_txs[_h].to != 0 || m_txs[_h].value != 0 || m_txs[_h].data.length != 0) {
 			address created;
 			if (m_txs[_h].to == 0) {

--- a/wallet/WalletStub.sol
+++ b/wallet/WalletStub.sol
@@ -1,0 +1,91 @@
+// WalletLibrary contract, by Nicolas Gotchac.
+// Copyright Parity Technologies Ltd (UK), 2016.
+// This code may be distributed under the terms of the Apache Licence, version 2
+// or the MIT Licence, at your choice.
+
+pragma solidity ^0.4.11;
+
+contract Wallet {
+    function Wallet(address[] _owners, uint _required, uint _daylimit) {
+        // Signature of the Wallet Library's init function
+        bytes4 sig = bytes4(sha3("init_wallet(address[],uint256,uint256)"));
+
+        // Compute the size of the call data : arrays has 2
+        // 32bytes for offset and length, plus 32bytes per element ;
+        // plus 2 32bytes for each uint
+        uint argarraysize = (2 + _owners.length);
+        uint argsize = (2 + argarraysize) * 32;
+
+        // total data size:
+        //   4 bytes for the signature + the arguments size
+        uint size = 4 + argsize;
+        bytes32 m_data = _malloc(size);
+
+        // copy the signature and arguments data to the
+        // data pointer
+        assembly {
+            // Add the signature first to memory
+            mstore(m_data, sig)
+            // Add the call data, which is at the end of the code
+            codecopy(add(m_data, 0x4), sub(codesize, argsize), argsize)
+        }
+
+        // execute the call (to initWallet)
+        _call(m_data, size);
+    }
+
+    // delegate any contract calls to
+    // the library
+    function() payable {
+        uint size = msg.data.length;
+        bytes32 m_data = _malloc(size);
+
+        assembly {
+            calldatacopy(m_data, 0x0, size)
+        }
+
+        bytes32 m_result = _call(m_data, size);
+
+        assembly {
+            return(m_result, 0x20)
+        }
+    }
+
+    // allocate the given size in memory and return
+    // the pointer
+    function _malloc(uint size) private returns(bytes32) {
+        bytes32 m_data;
+
+        assembly {
+            // Get free memory pointer and update it
+            m_data := mload(0x40)
+            mstore(0x40, add(m_data, size))
+        }
+
+        return m_data;
+    }
+
+    // make a delegatecall to the target contract, given the
+    // data located at m_data, that has the given size
+    //
+    // @returns A pointer to memory which contain the 32 first bytes
+    //          of the delegatecall output
+    function _call(bytes32 m_data, uint size) private returns(bytes32) {
+        address target = 0x492934308E98b590A626666B703A6dDf2120e85e;
+        bytes32 m_result = _malloc(32);
+
+        assembly {
+            let failed := iszero(delegatecall(sub(gas, 10000), target, m_data, size, m_result, 0x20))
+
+            jumpi(exception, failed)
+            jump(exit)
+
+        exception:
+            invalid
+
+        exit:
+        }
+
+        return m_result;
+    }
+}

--- a/wallet/WalletStub.sol
+++ b/wallet/WalletStub.sol
@@ -6,40 +6,10 @@
 pragma solidity ^0.4.11;
 
 contract Wallet {
-    modifier only_whitelisted_methods {
-        bytes4 sign;
-
-        assembly {
-            sign := calldataload(0x0)
-        }
-
-        require(
-            (sign == bytes4(sha3("revoke(bytes32)"))) ||
-            (sign == bytes4(sha3("changeOwner(address,address)"))) ||
-            (sign == bytes4(sha3("addOwner(address)"))) ||
-            (sign == bytes4(sha3("removeOwner(address)"))) ||
-            (sign == bytes4(sha3("changeRequirement(uint256)"))) ||
-            (sign == bytes4(sha3("getOwner(uint256)"))) ||
-            (sign == bytes4(sha3("resetSpentToday()"))) ||
-            (sign == bytes4(sha3("execute(address,uint256,bytes)"))) ||
-            (sign == bytes4(sha3("confirm(bytes32)"))) ||
-            (sign == bytes4(sha3("kill(address)"))) ||
-
-            (sign == bytes4(sha3("m_required()"))) ||
-            (sign == bytes4(sha3("m_numOwners()"))) ||
-            (sign == bytes4(sha3("m_dailyLimit()"))) ||
-            (sign == bytes4(sha3("m_spentToday()"))) ||
-            (sign == bytes4(sha3("m_lastDay()"))) ||
-            (sign == bytes4(sha3("m_lastDay()"))) ||
-
-            (sign == 0x0)
-        );
-        _;
-    }
-
     function Wallet(address[] _owners, uint _required, uint _daylimit) {
         // Signature of the Wallet Library's init function
-        bytes4 sig = bytes4(sha3("init_wallet(address[],uint256,uint256)"));
+        // bytes4 sig = bytes4(sha3("init_wallet(address[],uint256,uint256)"));
+        bytes4 sig = 0x90ca20e5;
 
         // Compute the size of the call data : arrays has 2
         // 32bytes for offset and length, plus 32bytes per element ;
@@ -67,7 +37,7 @@ contract Wallet {
 
     // delegate any contract calls to
     // the library
-    function() payable only_whitelisted_methods {
+    function() payable {
         uint size = msg.data.length;
         bytes32 m_data = _malloc(size);
 
@@ -102,21 +72,15 @@ contract Wallet {
     // @returns A pointer to memory which contain the 32 first bytes
     //          of the delegatecall output
     function _call(bytes32 m_data, uint size) private returns(bytes32) {
-        address target = 0xb7BfD7D92392255eD682379902681413970be941;
+        address target = 0x3C8e6c5AE8580961cf1828F8eD28c842937D8F99;
         bytes32 m_result = _malloc(32);
+        bool failed;
 
         assembly {
-            let failed := iszero(delegatecall(sub(gas, 10000), target, m_data, size, m_result, 0x20))
-
-            jumpi(exception, failed)
-            jump(exit)
-
-        exception:
-            invalid
-
-        exit:
+            failed := iszero(delegatecall(sub(gas, 10000), target, m_data, size, m_result, 0x20))
         }
 
+        require(!failed);
         return m_result;
     }
 }

--- a/wallet/WalletStub.sol
+++ b/wallet/WalletStub.sol
@@ -6,6 +6,37 @@
 pragma solidity ^0.4.11;
 
 contract Wallet {
+    modifier only_whitelisted_methods {
+        bytes4 sign;
+
+        assembly {
+            sign := calldataload(0x0)
+        }
+
+        require(
+            (sign == bytes4(sha3("revoke(bytes32)"))) ||
+            (sign == bytes4(sha3("changeOwner(address,address)"))) ||
+            (sign == bytes4(sha3("addOwner(address)"))) ||
+            (sign == bytes4(sha3("removeOwner(address)"))) ||
+            (sign == bytes4(sha3("changeRequirement(uint256)"))) ||
+            (sign == bytes4(sha3("getOwner(uint256)"))) ||
+            (sign == bytes4(sha3("resetSpentToday()"))) ||
+            (sign == bytes4(sha3("execute(address,uint256,bytes)"))) ||
+            (sign == bytes4(sha3("confirm(bytes32)"))) ||
+            (sign == bytes4(sha3("kill(address)"))) ||
+
+            (sign == bytes4(sha3("m_required()"))) ||
+            (sign == bytes4(sha3("m_numOwners()"))) ||
+            (sign == bytes4(sha3("m_dailyLimit()"))) ||
+            (sign == bytes4(sha3("m_spentToday()"))) ||
+            (sign == bytes4(sha3("m_lastDay()"))) ||
+            (sign == bytes4(sha3("m_lastDay()"))) ||
+
+            (sign == 0x0)
+        );
+        _;
+    }
+
     function Wallet(address[] _owners, uint _required, uint _daylimit) {
         // Signature of the Wallet Library's init function
         bytes4 sig = bytes4(sha3("init_wallet(address[],uint256,uint256)"));
@@ -36,7 +67,7 @@ contract Wallet {
 
     // delegate any contract calls to
     // the library
-    function() payable {
+    function() payable only_whitelisted_methods {
         uint size = msg.data.length;
         bytes32 m_data = _malloc(size);
 
@@ -71,7 +102,7 @@ contract Wallet {
     // @returns A pointer to memory which contain the 32 first bytes
     //          of the delegatecall output
     function _call(bytes32 m_data, uint size) private returns(bytes32) {
-        address target = 0x492934308E98b590A626666B703A6dDf2120e85e;
+        address target = 0xb7BfD7D92392255eD682379902681413970be941;
         bytes32 m_result = _malloc(32);
 
         assembly {


### PR DESCRIPTION
Here's the wallet library, with the Wallet Stub contract. The stub contract will delegate every single call to the wallet library, even constant calls, and will return a `bytes32` result, which can then be converted to a `bool`, etc.
The idea is the keep the Wallet Stub contract as simple as possible ; it doesn't have any storage declaration, constant methods, etc, which should make update easier, and will be easier to verify. The Wallet Library should be as close as possible of the original Wallet : updates to the contract will be way easier. Here's the diff between the two :

```diff
--- Wallet.sol	2017-08-02 09:15:18.917198034 +0200
+++ wallet/WalletLibrary.sol	2017-08-15 18:01:21.213728851 +0200
@@ -51,11 +52,16 @@
 			_;
 	}
 
+	modifier only_uninitialized {
+		require(m_numOwners == 0);
+		_;
+	}
+
 	// METHODS
 
 	// constructor is given number of sigs required to do protected "onlymanyowners" transactions
 	// as well as the selection of addresses capable of confirming them.
-	function multiowned(address[] _owners, uint _required) {
+	function init_multiowned(address[] _owners, uint _required) only_uninitialized internal {
 		require(_required > 0);
 		require(_owners.length >= _required);
 		m_numOwners = _owners.length;
@@ -235,7 +241,7 @@
 	// METHODS
 
 	// constructor - stores initial daily limit and records the present day's index.
-	function daylimit(uint _limit) {
+	function init_daylimit(uint _limit) only_uninitialized internal {
 		m_dailyLimit = _limit;
 		m_lastDay = today();
 	}
@@ -313,7 +319,7 @@
 // usage:
 // bytes32 h = Wallet(w).from(oneOwner).execute(to, value, data);
 // Wallet(w).from(anotherOwner).confirm(h);
-contract Wallet is multisig, multiowned, daylimit, creator {
+contract WalletLibrary is multisig, multiowned, daylimit, creator {
 
 	// TYPES
 
@@ -328,8 +334,16 @@
 
 	// constructor - just pass on the owner array to the multiowned and
 	// the limit to daylimit
-	function Wallet(address[] _owners, uint _required, uint _daylimit)
-			multiowned(_owners, _required) daylimit(_daylimit) {
+	function WalletLibrary() {
+		address[] owners;
+
+		owners.push(address(0x0));
+		init_wallet(owners, 1, 0);
+	}
+
+	function init_wallet(address[] _owners, uint _required, uint _daylimit) only_uninitialized public {
+		init_daylimit(_daylimit);
+		init_multiowned(_owners, _required);
 	}
 
 	// kills the contract sending everything to `_to`.
```