### PR TITLE
Refactor: explicit visibility, require/assert

### DIFF
--- a/Operations.sol
+++ b/Operations.sol
@@ -2,9 +2,9 @@
 // Copyright Parity Technologies Ltd (UK), 2016.
 // This code may be distributed under the terms of the Apache Licence, version 2.
 
-pragma solidity ^0.4.7;
+pragma solidity ^0.4.11;
 
-contract OperationsFace {
+interface OperationsFace {
 	function proposeTransaction(bytes32 _txid, address _to, bytes _data, uint _value, uint _gas) returns (uint txSuccess);
 	function confirmTransaction(bytes32 _txid) returns (uint txSuccess);
 	function rejectTransaction(bytes32 _txid);
@@ -93,15 +93,15 @@ contract Operations is OperationsFace {
 
 	function Operations() {
 /*		// Mainnet
-		fork[0] = Fork("frontier", sha3("frontier"), true, true, 0);
-		fork[1150000] = Fork("homestead", sha3("homestead"), true, true, 0);
-		fork[2463000] = Fork("eip150", sha3("eip150"), true, true, 0);
-		fork[2675000] = Fork("eip155", sha3("eip155"), true, true, 0);
+		fork[0] = Fork("frontier", keccak256("frontier"), true, true, 0);
+		fork[1150000] = Fork("homestead", keccak256("homestead"), true, true, 0);
+		fork[2463000] = Fork("eip150", keccak256("eip150"), true, true, 0);
+		fork[2675000] = Fork("eip155", keccak256("eip155"), true, true, 0);
 		latestFork = 2675000;
 */
 		// Ropsten
-		fork[0] = Fork("eip150", sha3("eip150"), true, true, 0);
-		fork[10] = Fork("eip155", sha3("eip155"), true, true, 0);
+		fork[0] = Fork("eip150", keccak256("eip150"), true, true, 0);
+		fork[10] = Fork("eip155", keccak256("eip155"), true, true, 0);
 		latestFork = 10;
 
 		client["parity"] = Client(msg.sender, true);
@@ -113,7 +113,12 @@ contract Operations is OperationsFace {
 
 	// Functions for client owners
 
-	function proposeTransaction(bytes32 _txid, address _to, bytes _data, uint _value, uint _gas) only_required_client_owner only_when_no_proxy(_txid) returns (uint txSuccess) {
+	function proposeTransaction(bytes32 _txid, address _to, bytes _data, uint _value, uint _gas)
+        only_required_client_owner
+        only_when_no_proxy(_txid)
+        public
+        returns (uint txSuccess)
+    {
 		var client = clientOwner[msg.sender];
 		proxy[_txid] = Transaction(1, _to, _data, _value, _gas);
 		proxy[_txid].status[client] = Status.Accepted;
@@ -121,7 +126,13 @@ contract Operations is OperationsFace {
 		TransactionProposed(client, _txid, _to, _data, _value, _gas);
 	}
 
-	function confirmTransaction(bytes32 _txid) only_required_client_owner only_when_proxy(_txid) only_when_proxy_undecided(_txid) returns (uint txSuccess) {
+	function confirmTransaction(bytes32 _txid) 
+        only_required_client_owner
+        only_when_proxy(_txid)
+        only_when_proxy_undecided(_txid) 
+        public
+        returns (uint txSuccess) 
+    {
 		var client = clientOwner[msg.sender];
 		proxy[_txid].status[client] = Status.Accepted;
 		proxy[_txid].requiredCount += 1;
@@ -129,32 +140,53 @@ contract Operations is OperationsFace {
 		TransactionConfirmed(client, _txid);
 	}
 
-	function rejectTransaction(bytes32 _txid) only_required_client_owner only_when_proxy(_txid) only_when_proxy_undecided(_txid) {
+	function rejectTransaction(bytes32 _txid)
+        only_required_client_owner
+        only_when_proxy(_txid)
+        only_when_proxy_undecided(_txid)
+        public
+    {
 		delete proxy[_txid];
 		TransactionRejected(clientOwner[msg.sender], _txid);
 	}
 
-	function proposeFork(uint32 _number, bytes32 _name, bool _hard, bytes32 _spec) only_client_owner only_when_none_proposed {
+	function proposeFork(uint32 _number, bytes32 _name, bool _hard, bytes32 _spec)
+        only_client_owner
+        only_when_none_proposed
+        public
+    {
 		fork[_number] = Fork(_name, _spec, _hard, false, 0);
 		proposedFork = _number;
 		ForkProposed(clientOwner[msg.sender], _number, _name, _spec, _hard);
 	}
 
-	function acceptFork() only_when_proposed only_undecided_client_owner {
+	function acceptFork()
+        only_when_proposed
+        only_undecided_client_owner
+        public
+    {
 		var newClient = clientOwner[msg.sender];
 		fork[proposedFork].status[newClient] = Status.Accepted;
 		ForkAcceptedBy(newClient, proposedFork);
 		noteAccepted(newClient);
 	}
 
-	function rejectFork() only_when_proposed only_undecided_client_owner only_unratified {
+	function rejectFork()
+        only_when_proposed
+        only_undecided_client_owner
+        only_unratified
+        public
+    {
 		var newClient = clientOwner[msg.sender];
 		fork[proposedFork].status[newClient] = Status.Rejected;
 		ForkRejectedBy(newClient, proposedFork);
 		noteRejected(newClient);
 	}
 
-	function setClientOwner(address _newOwner) only_client_owner {
+	function setClientOwner(address _newOwner)
+        only_client_owner
+        public
+    {
 		var newClient = clientOwner[msg.sender];
 		clientOwner[msg.sender] = 0;
 		clientOwner[_newOwner] = newClient;
@@ -162,14 +194,20 @@ contract Operations is OperationsFace {
 		ClientOwnerChanged(newClient, msg.sender, _newOwner);
 	}
 
-	function addRelease(bytes32 _release, uint32 _forkBlock, uint8 _track, uint24 _semver, bool _critical) only_client_owner {
+	function addRelease(bytes32 _release, uint32 _forkBlock, uint8 _track, uint24 _semver, bool _critical)
+        only_client_owner
+        public
+    {
 		var newClient = clientOwner[msg.sender];
 		client[newClient].release[_release] = Release(_forkBlock, _track, _semver, _critical);
 		client[newClient].current[_track] = _release;
 		ReleaseAdded(newClient, _forkBlock, _release, _track, _semver, _critical);
 	}
 
-	function addChecksum(bytes32 _release, bytes32 _platform, bytes32 _checksum) only_client_owner {
+	function addChecksum(bytes32 _release, bytes32 _platform, bytes32 _checksum)
+        only_client_owner
+        public
+    {
 		var newClient = clientOwner[msg.sender];
 		client[newClient].build[_checksum] = Build(_release, _platform);
 		client[newClient].release[_release].checksum[_platform] = _checksum;
@@ -178,20 +216,29 @@ contract Operations is OperationsFace {
 
 	// Admin functions
 
-	function addClient(bytes32 _client, address _owner) only_owner {
+	function addClient(bytes32 _client, address _owner)
+        only_owner
+        public
+    {
 		client[_client].owner = _owner;
 		clientOwner[_owner] = _client;
 		ClientAdded(_client, _owner);
 	}
 
-	function removeClient(bytes32 _client) only_owner {
+	function removeClient(bytes32 _client)
+        only_owner
+        public
+    {
 		setClientRequired(_client, false);
 		resetClientOwner(_client, 0);
 		delete client[_client];
 		ClientRemoved(_client);
 	}
 
-	function resetClientOwner(bytes32 _client, address _newOwner) only_owner {
+	function resetClientOwner(bytes32 _client, address _newOwner)
+        only_owner
+        public
+    {
 		var old = client[_client].owner;
 		ClientOwnerChanged(_client, old, _newOwner);
 		clientOwner[old] = 0;
@@ -199,39 +246,66 @@ contract Operations is OperationsFace {
 		client[_client].owner = _newOwner;
 	}
 
-	function setClientRequired(bytes32 _client, bool _r) only_owner when_changing_required(_client, _r) {
+	function setClientRequired(bytes32 _client, bool _r)
+        only_owner
+        when_changing_required(_client, _r)
+        public
+    {
 		ClientRequiredChanged(_client, _r);
 		client[_client].required = _r;
 		clientsRequired = _r ? clientsRequired + 1 : (clientsRequired - 1);
 		checkFork();
 	}
 
-	function setOwner(address _newOwner) only_owner {
+	function setOwner(address _newOwner)
+        only_owner
+        public
+    {
 		OwnerChanged(grandOwner, _newOwner);
 		grandOwner = _newOwner;
 	}
 
 	// Getters
 
-	function isLatest(bytes32 _client, bytes32 _release) constant returns (bool) {
+	function isLatest(bytes32 _client, bytes32 _release)
+        constant
+        public
+        returns (bool)
+    {
 		return latestInTrack(_client, track(_client, _release)) == _release;
 	}
 
-	function track(bytes32 _client, bytes32 _release) constant returns (uint8) {
+	function track(bytes32 _client, bytes32 _release)
+        constant
+        public
+        returns (uint8)
+    {
 		return client[_client].release[_release].track;
 	}
 
-	function latestInTrack(bytes32 _client, uint8 _track) constant returns (bytes32) {
+	function latestInTrack(bytes32 _client, uint8 _track)
+        constant
+        public
+        returns (bytes32)
+    {
 		return client[_client].current[_track];
 	}
 
-	function build(bytes32 _client, bytes32 _checksum) constant returns (bytes32 o_release, bytes32 o_platform) {
+	function build(bytes32 _client, bytes32 _checksum)
+        constant
+        public
+        returns (bytes32 o_release, bytes32 o_platform)
+    {
 		var b = client[_client].build[_checksum];
 		o_release = b.release;
 		o_platform = b.platform;
 	}
 
-	function release(bytes32 _client, bytes32 _release) constant returns (uint32 o_forkBlock, uint8 o_track, uint24 o_semver, bool o_critical) {
+	function release(bytes32 _client, bytes32 _release)
+        constant
+        public
+        returns (uint32 o_forkBlock, uint8 o_track, uint24 o_semver, bool o_critical)
+    {
 		var b = client[_client].release[_release];
 		o_forkBlock = b.forkBlock;
 		o_track = b.track;
@@ -239,63 +313,136 @@ contract Operations is OperationsFace {
 		o_critical = b.critical;
 	}
 
-	function checksum(bytes32 _client, bytes32 _release, bytes32 _platform) constant returns (bytes32) {
+	function checksum(bytes32 _client, bytes32 _release, bytes32 _platform)
+        constant
+        public
+        returns (bytes32)
+    {
 		return client[_client].release[_release].checksum[_platform];
 	}
 
 	// Internals
 
-	function noteAccepted(bytes32 _client) internal when_required(_client) {
+	function noteAccepted(bytes32 _client)
+        when_required(_client)
+        internal
+    {
 		fork[proposedFork].requiredCount += 1;
 		checkFork();
 	}
 
-	function noteRejected(bytes32 _client) internal when_required(_client) {
+	function noteRejected(bytes32 _client)
+        when_required(_client)
+        internal 
+    {
 		ForkRejected(proposedFork);
 		delete fork[proposedFork];
 		proposedFork = 0;
 	}
 
-	function checkFork() internal when_have_all_required {
+	function checkFork()
+        when_have_all_required
+        internal
+    {
 		ForkRatified(proposedFork);
 		fork[proposedFork].ratified = true;
 		latestFork = proposedFork;
 		proposedFork = 0;
 	}
 
-	function checkProxy(bytes32 _txid) internal when_proxy_confirmed(_txid) returns (uint txSuccess) {
+	function checkProxy(bytes32 _txid)
+        when_proxy_confirmed(_txid)
+        internal
+        returns (uint txSuccess)
+    {
 		var tx = proxy[_txid];
+		delete proxy[_txid];
+        // TODO: refactor to use a push-pull pattern if possible
+        //
+        // state changes shouldn't occur after calling out to external
+        // contract. 
 		var success = tx.to.call.value(tx.value).gas(tx.gas)(tx.data);
 		TransactionRelayed(_txid, success);
 		txSuccess = success ? 2 : 1;
-		delete proxy[_txid];
 	}
 
 	// Modifiers
 
-	modifier only_owner { if (grandOwner != msg.sender) throw; _; }
-	modifier only_client_owner { var newClient = clientOwner[msg.sender]; if (newClient == 0) throw; _; }
-	modifier only_required_client_owner { var newClient = clientOwner[msg.sender]; if (!client[newClient].required) throw; _; }
-	modifier only_ratified{ if (!fork[proposedFork].ratified) throw; _; }
-	modifier only_unratified { if (!fork[proposedFork].ratified) throw; _; }
+	modifier only_owner
+    {
+        require(grandOwner == msg.sender);
+        _;
+    }
+	modifier only_client_owner {
+        var newClient = clientOwner[msg.sender];
+        require(newClient != 0);
+        _;
+    }
+    modifier only_required_client_owner { 
+        var newClient = clientOwner[msg.sender]; 
+        require(client[newClient].required); _;
+    }
+	modifier only_ratified{
+        assert(fork[proposedFork].ratified);
+        _;
+    }
+	modifier only_unratified
+    {
+        assert(!fork[proposedFork].ratified);
+        _;
+    }
 	modifier only_undecided_client_owner {
 		var newClient = clientOwner[msg.sender];
-		if (newClient == 0)
-			throw;
-		if (fork[proposedFork].status[newClient] != Status.Undecided)
-			throw;
-		_;
+		require(newClient != 0);
+		require(fork[proposedFork].status[newClient] == Status.Undecided);
+        _;
 	}
-	modifier only_when_none_proposed { if (proposedFork != 0) throw; _; }
-	modifier only_when_proposed { if (fork[proposedFork].name == 0) throw; _; }
-	modifier only_when_proxy(bytes32 _txid) { if (proxy[_txid].requiredCount == 0) throw; _; }
-	modifier only_when_no_proxy(bytes32 _txid) { if (proxy[_txid].requiredCount > 0) throw; _; }
-	modifier only_when_proxy_undecided(bytes32 _txid) { if (proxy[_txid].status[clientOwner[msg.sender]] != Status.Undecided) throw; _; }
+	modifier only_when_none_proposed
+    {
+        assert(proposedFork == 0);
+        _;
+    }
+	modifier only_when_proposed
+    {
+        assert(fork[proposedFork].name != 0);
+        _;
+    }
+	modifier only_when_proxy(bytes32 _txid)
+    {
+        assert(proxy[_txid].requiredCount > 0);
+        _;
+    }
+	modifier only_when_no_proxy(bytes32 _txid)
+    {
+        assert(proxy[_txid].requiredCount == 0);
+        _;
+    }
+	modifier only_when_proxy_undecided(bytes32 _txid)
+    { 
+        require(proxy[_txid].status[clientOwner[msg.sender]] == Status.Undecided);
+        _; 
+    }
 
-	modifier when_required(bytes32 _client) { if (client[_client].required) _; }
-	modifier when_have_all_required { if (fork[proposedFork].requiredCount >= clientsRequired) _; }
-	modifier when_changing_required(bytes32 _client, bool _r) { if (client[_client].required != _r) _; }
-	modifier when_proxy_confirmed(bytes32 _txid) { if (proxy[_txid].requiredCount >= clientsRequired) _; }
+	modifier when_required(bytes32 _client)
+    {
+        require(client[_client].required);
+        _;
+    }
+	modifier when_have_all_required
+    {
+        require(fork[proposedFork].requiredCount >= clientsRequired);
+        _;
+    }
+	modifier when_changing_required(bytes32 _client, bool _r)
+    {
+        require(client[_client].required != _r);
+        _;
+    }
+	modifier when_proxy_confirmed(bytes32 _txid)
+    {
+        require(proxy[_txid].requiredCount >= clientsRequired);
+        _;
+    }
 
 	mapping (uint32 => Fork) public fork;
 	mapping (bytes32 => Client) public client;


### PR DESCRIPTION
Refactored functions to include explicit visibility, and change
modifiers to use `require()` and `assert()`.

Updated to compiler 0.4.11

Changed `OperationsFace` contract to an interface for increased safety.
By changing to an interface, `OperationsFace` cannot itself be constructed.
Also made some readability changes, and other minor updates. 

This contract still needs a higher-level business logic review, and unit/integration/security tests.